### PR TITLE
(FIX): Don't Expose Redis Port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     container_name: cam-running
   cam-redis:
     image: "redis:3.0"
-    ports:
-      - "6379:6379"
+    expose:
+      - "6379"
     container_name: cam-redis


### PR DESCRIPTION
Context
======
The redis service in the compose file accidentally forwarded the host's 6379 port to the container. Oops.

Let's just not do that.

Technical
=======
Changed the redis service to use expose instead of ports, this way it's only exposed to linked containers.

TODO
======
 - [ ] CR
 - [ ] QA